### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.3.0] - 2023-11-08
 
 ## [0.2.1] - 2023-10-26

--- a/helm/grafana-agent/values.yaml
+++ b/helm/grafana-agent/values.yaml
@@ -1,6 +1,6 @@
 global:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
 
 # Enable Kyverno PolicyException
 kyvernoPolicyExceptions:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
