### PR TITLE
Enable CNP egress/ingress override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Restrict CiliumNetworkPolicy.
+- Enable CNP egress/ingress override.
 
 ## [0.4.3] - 2024-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Restrict CiliumNetworkPolicy.
+
 ## [0.4.3] - 2024-03-14
 
 ### Fixed

--- a/helm/grafana-agent/templates/cilium-networkpolicy.yaml
+++ b/helm/grafana-agent/templates/cilium-networkpolicy.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- include "grafana-agent.labels" . | nindent 4 }}
 spec:
   egress:
-  {{- if .Values.networkPolicy.egress }}
-  {{- toYaml .Values.networkPolicy.egress | nindent 2 }}
+  {{- if .Values.networkPolicy.cilium.egress }}
+  {{- toYaml .Values.networkPolicy.cilium.egress | nindent 2 }}
   {{- else }}
   - toEntities:
     - kube-apiserver
@@ -33,8 +33,8 @@ spec:
     matchLabels:
       {{- include "grafana-agent.selectorLabels" . | nindent 6 }}
   ingress:
-  {{- if .Values.networkPolicy.ingress }}
-  {{- toYaml .Values.networkPolicy.ingress | nindent 2 }}
+  {{- if .Values.networkPolicy.cilium.ingress }}
+  {{- toYaml .Values.networkPolicy.cilium.ingress | nindent 2 }}
   {{- else }}
   - toPorts:
     - ports:

--- a/helm/grafana-agent/templates/cilium-networkpolicy.yaml
+++ b/helm/grafana-agent/templates/cilium-networkpolicy.yaml
@@ -8,41 +8,37 @@ metadata:
     {{- include "grafana-agent.labels" . | nindent 4 }}
 spec:
   egress:
+  {{- if .Values.networkPolicy.egress }}
+  {{- toYaml .Values.networkPolicy.egress | nindent 2 }}
+  {{- else }}
   - toEntities:
     - kube-apiserver
     - world
   - toEndpoints:
     - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: coredns
+      k8s-app: coredns
     - matchLabels:
-        io.kubernetes.pod.namespace: kube-system
-        k8s-app: k8s-dns-node-cache
+      k8s-app: k8s-dns-node-cache
     toPorts:
     - ports:
-      - port: "1053"
-        protocol: UDP
-      - port: "1053"
-        protocol: TCP
       - port: "53"
-        protocol: UDP
-      - port: "53"
-        protocol: TCP
-  - toEndpoints:
-    - matchLabels:
-        app.kubernetes.io/component: ruler
-        app.kubernetes.io/name: mimir
-        io.kubernetes.pod.namespace: mimir
-    toPorts:
-    - ports:
-      - port: "8080"
-        protocol: TCP
+        protocol: ANY
+      - port: "1053"
+        protocol: ANY
+      rules:
+        dns:
+        - matchPattern: '*'
+  {{- end }}
   endpointSelector:
     matchLabels:
       {{- include "grafana-agent.selectorLabels" . | nindent 6 }}
   ingress:
+  {{- if .Values.networkPolicy.ingress }}
+  {{- toYaml .Values.networkPolicy.ingress | nindent 2 }}
+  {{- else }}
   - toPorts:
     - ports:
       - port: "8080"
         protocol: TCP
+  {{- end }}
 {{- end }}

--- a/helm/grafana-agent/templates/cilium-networkpolicy.yaml
+++ b/helm/grafana-agent/templates/cilium-networkpolicy.yaml
@@ -7,30 +7,42 @@ metadata:
   labels:
     {{- include "grafana-agent.labels" . | nindent 4 }}
 spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+    - world
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: coredns
+    - matchLabels:
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: k8s-dns-node-cache
+    toPorts:
+    - ports:
+      - port: "1053"
+        protocol: UDP
+      - port: "1053"
+        protocol: TCP
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+  - toEndpoints:
+    - matchLabels:
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/name: mimir
+        io.kubernetes.pod.namespace: mimir
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
   endpointSelector:
     matchLabels:
       {{- include "grafana-agent.selectorLabels" . | nindent 6 }}
   ingress:
-    - toPorts:
-      - ports:
-        - port: "8080"
-          protocol: TCP
-  egress:
-    - toEntities:
-        - kube-apiserver
-        - world
-    - toEndpoints:
-      - matchLabels:
-          k8s-app: coredns
-      - matchLabels:
-          k8s-app: k8s-dns-node-cache
-      toPorts:
-      - ports:
-        - port: "53"
-          protocol: ANY
-        - port: "1053"
-          protocol: ANY
-        rules:
-          dns:
-          - matchPattern: '*'
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
 {{- end }}

--- a/helm/grafana-agent/values.schema.json
+++ b/helm/grafana-agent/values.schema.json
@@ -93,14 +93,19 @@
         "networkPolicy": {
             "type": "object",
             "properties": {
-                "egress": {
-                    "type": "array"
+                "cilium": {
+                    "type": "object",
+                    "properties": {
+                        "egress": {
+                            "type": "array"
+                        },
+                        "ingress": {
+                            "type": "array"
+                        }
+                    }
                 },
                 "flavor": {
                     "type": "string"
-                },
-                "ingress": {
-                    "type": "array"
                 }
             }
         },

--- a/helm/grafana-agent/values.schema.json
+++ b/helm/grafana-agent/values.schema.json
@@ -58,6 +58,9 @@
                         }
                     }
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "image": {
                     "type": "object",
                     "properties": {
@@ -90,8 +93,14 @@
         "networkPolicy": {
             "type": "object",
             "properties": {
+                "egress": {
+                    "type": "array"
+                },
                 "flavor": {
                     "type": "string"
+                },
+                "ingress": {
+                    "type": "array"
                 }
             }
         },

--- a/helm/grafana-agent/values.yaml
+++ b/helm/grafana-agent/values.yaml
@@ -9,6 +9,9 @@ kyvernoPolicyExceptions:
 
 networkPolicy:
   flavor: cilium
+  # You can override CNP egress/ingress rules
+  egress: []
+  ingress: []
 
 psp:
   enabled: false

--- a/helm/grafana-agent/values.yaml
+++ b/helm/grafana-agent/values.yaml
@@ -9,9 +9,10 @@ kyvernoPolicyExceptions:
 
 networkPolicy:
   flavor: cilium
-  # You can override CNP egress/ingress rules
-  egress: []
-  ingress: []
+  cilium:
+    # You can override CNP egress/ingress rules
+    egress: []
+    ingress: []
 
 psp:
   enabled: false


### PR DESCRIPTION
<!--
@team-atlas will be automatically requested for review once
this PR has been submitted.
-->
towards https://github.com/giantswarm/giantswarm/issues/30870

The idea is to allow the user to override the egress/ingress of the CiliumNetworkPolicy by default.
Hence, we can restrict that CNP for our needs for the grafana-agent responsible for sending rules to Mimir on all MCs.
