### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Here we define the Grafana Agent chart with its templates and default configurat
 
 **Who can use it?**
 
+## ⚠️  Deprecation notice
+
+grafana-agent has been replaced by [Alloy](https://github.com/giantswarm/alloy-app/).
+grafana-agent is not used anymore, and it is now deprecated.
+
 ## Installing
 
 There are several ways to install this app onto a workload cluster.


### PR DESCRIPTION
Now that new clusters are running Alloy, we probably don't want to keep supporting this app.
Let's add a deprecation notice then archive the repo.